### PR TITLE
Use external config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip3 install selenium
 
 COPY ./flat_updater.py /opt/bin/flat_updater.py
 COPY ./start.sh /opt/bin/start.sh
+COPY ./config.json /opt/bin/config.json
 RUN sudo chmod +x /opt/bin/start.sh
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You'll need to install **selenium-webdriver** first:
 pip install selenium
 ```
 
-Then adjust the config at the beginning of the file and run the script
+Then adjust the configuration in `config.json` and run the script
 
 ```
 python flat_updater.py

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "login": {
+    "username": "",
+    "password": ""
+  },
+  "offer": {
+    "id": "",
+    "interval": 10
+  }
+}

--- a/flat_updater.py
+++ b/flat_updater.py
@@ -1,20 +1,17 @@
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
+import json
+import os
 import time
 import random
 
 
-config = {
-    'login': {
-        'username': '',  # Your email address
-        'password': '',  # Your password
-    },
-    'offer': {
-        'id': '',  # Your offer ID
-        'interval': 10,  # Update interval in minutes
-    },
-}
+
+# Load configuration from external JSON file located next to this script.
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.json")
+with open(CONFIG_FILE, "r") as fh:
+    config = json.load(fh)
 
 screen = {
     'width': 640,


### PR DESCRIPTION
## Summary
- move inline config to `config.json`
- load config from this file at runtime
- copy `config.json` into Docker image
- update README instructions

## Testing
- `python3 -m py_compile flat_updater.py`


------
https://chatgpt.com/codex/tasks/task_e_68660f761c0c8332bcf4469c10111129